### PR TITLE
Add support for Apple Pay JS version 2

### DIFF
--- a/ApplePaySession.js
+++ b/ApplePaySession.js
@@ -15,6 +15,7 @@
             self.paymentsEnabled = true;
             self.paymentRequest = null;
             self.merchantIdentifier = "";
+            self.supportedVersions = [1, 2];
             self.validationURL = "https://apple-pay-gateway-cert.apple.com/paymentservices/startSession";
             self.version = 1;
 
@@ -87,7 +88,7 @@
                     throw "Page already has an active payment session.";
                 }
 
-                if (version !== self.version) {
+                if (self.supportedVersions.indexOf(version) === -1) {
                     throw "\"" + version + "\" is not a supported version.";
                 }
 
@@ -99,6 +100,10 @@
                 var currencyCodes = ["AUD", "CAD", "CHF", "CNY", "EUR", "GBP", "HKD", "SGD", "USD"];
                 var merchantCapabilities = ["supports3DS", "supportsEMV", "supportsCredit", "supportsDebit"];
                 var paymentNetworks = ["amex", "discover", "interac", "masterCard", "privateLabel", "visa"];
+
+                if (version > 1) {
+                    paymentNetworks.push("jcb");
+                }
 
                 if (countryCodes.indexOf(paymentRequest.countryCode) === -1) {
                     throw "\"" + paymentRequest.countryCode + "\" is not valid country code.";
@@ -190,9 +195,9 @@
             self.onCanMakePaymentsWithActiveCard = function (session, merchantIdentifier) {
 
                 var result =
-                       self.paymentsEnabled === true &&
-                       merchantIdentifier &&
-                       merchantIdentifier === self.merchantIdentifier;
+                    self.paymentsEnabled === true &&
+                    merchantIdentifier &&
+                    merchantIdentifier === self.merchantIdentifier;
 
                 return Promise.resolve(result);
             };
@@ -283,7 +288,7 @@
              * @return {Boolean} The value to return from ApplePaySession.supportsVersion().
              */
             self.onSupportsVersion = function (session, version) {
-                return version === self.version;
+                return self.supportedVersions.indexOf(version) !== -1;
             };
 
             return self;

--- a/ApplePaySession.js
+++ b/ApplePaySession.js
@@ -12,6 +12,7 @@
             var self = {};
 
             self.hasActiveSession = false;
+            self.isApplePaySetUp = true;
             self.paymentsEnabled = true;
             self.paymentRequest = null;
             self.merchantIdentifier = "";
@@ -39,6 +40,14 @@
              */
             self.setMerchantIdentifier = function (merchantIdentifier) {
                 self.merchantIdentifier = merchantIdentifier;
+            };
+
+            /**
+             * Sets whether the user has set up Apple Pay.
+             * @param {Boolean} isSetUp - Whether Apple Pay has been set up by the user on the device.
+             */
+            self.setUserSetupStatus = function (isSetUp) {
+                self.isApplePaySetUp = isSetUp;
             };
 
             /**
@@ -282,6 +291,25 @@
             };
 
             /**
+             * Callback for ApplePaySession.openPaymentSetup().
+             * @param {Object} session - The current ApplePaySession.
+             * @param {String} merchantIdentifier - The merchant identifier passed to the function.
+             */
+            self.onOpenPaymentSetup = function (session, merchantIdentifier) {
+
+                var result =
+                    self.paymentsEnabled === true &&
+                    merchantIdentifier &&
+                    merchantIdentifier === self.merchantIdentifier;
+
+                if (result === true) {
+                    result = self.isApplePaySetUp;
+                }
+
+                return Promise.resolve(result);
+            };
+
+            /**
              * Callback for ApplePaySession.supportsVersion().
              * @param {Object} session - The current ApplePaySession.
              * @param {Number} version - The version passed to the function.
@@ -321,6 +349,10 @@
 
         ApplePaySession.canMakePaymentsWithActiveCard = function (merchantIdentifier) {
             return ApplePaySessionPolyfill.onCanMakePaymentsWithActiveCard(this, merchantIdentifier);
+        };
+
+        ApplePaySession.openPaymentSetup = function (merchantIdentifier) {
+            return ApplePaySessionPolyfill.onOpenPaymentSetup(this, merchantIdentifier);
         };
 
         ApplePaySession.supportsVersion = function (version) {

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Apple Pay JS is a way of accepting Apple Pay in websites using Safari in either 
 
 This polyfill provides a way to make [```ApplePaySession```](https://developer.apple.com/reference/applepayjs/applepaysession) available for testing your implementation in browsers that would otherwise not provide support for Apple Pay JS, such as in Chrome on Windows.
 
+The polyfill supports Apple Pay JS versions 1 and 2.
+
 ## Examples
 
 To create a minimal working integration using the polyfill, first install the JavaScript using [bower](https://bower.io/):
@@ -91,6 +93,22 @@ if ("ApplePaySession" in window && ApplePaySession.canMakePayments() === true) {
 
   });
 }
+```
+
+### Apple Pay Set Up
+
+If you need to test displaying the "Set Up Apple Pay" button, use the ```setUserSetupStatus(bool)``` function, as shown below, to specify that the user has not yet set up Apple Pay on the device.
+
+```js
+ApplePaySessionPolyfill.setUserSetupStatus(false);
+```
+
+By default this value is set to ```true``` so that Apple Pay is available in the polyfill.
+
+If you need to test compatibility with devices that do not support Apple Pay set up, then delete the function from ```ApplePaySession``` before your implementation code is loaded:
+
+```js
+delete ApplePaySession.openPaymentSetup;
 ```
 
 ## Feedback


### PR DESCRIPTION
This PR updates the polyfill to support Apple Pay JS version 2.

  1. ```ApplePaySession(version, paymentRequest)``` now accepts a value of ```2``` for ```version```.
  1. ```ApplePaySession.supportsVersion(version)``` now returns ```true``` if the value of ```version``` is ```2```.
  1. ```ApplePaySession(version, paymentRequest)``` now accepts the value ```"jcb"``` as a supported network if the value of ```version``` is ```2``` or greater.
  1. ```ApplePaySession.openPaymentSetup(merchantIdentifier)``` is now supported.