### PR TITLE
Mock the timeout limit from onpaymentauthorized

### DIFF
--- a/ApplePaySession.js
+++ b/ApplePaySession.js
@@ -401,7 +401,7 @@
             };
 
             /**
-             * Callback for ApplePaySession.completePaymentMethodSelection() for Apple Pay JS version 3 and above.
+             * Used internally to set the payment timeout before calling "onpaymentauthorized".
              * @param {Object} session - The current ApplePaySession.
              * @param {Object} applePayPaymentAuthorizedEvent - The event sent to onpaymentauthorized.
              */

--- a/ApplePaySession.js
+++ b/ApplePaySession.js
@@ -18,6 +18,7 @@
             self.paymentRequest = null;
             self.merchantIdentifier = "";
             self.supportedVersions = [];
+            self.authorizationTimeout = 0;
             self.validationURL = "https://apple-pay-gateway-cert.apple.com/paymentservices/startSession";
             self.version = latestApplePayVersion;
 
@@ -342,7 +343,8 @@
                             shippingContact: self.createShippingContact(session)
                         }
                     };
-                    session.onpaymentauthorized(applePayPaymentAuthorizedEvent);
+
+                    self.onPaymentAuthorizedWithTimeout(session, applePayPaymentAuthorizedEvent);
                 }
             };
 
@@ -354,6 +356,8 @@
             self.onCompletePayment = function (session, status) {
                 self.hasActiveSession = false;
                 self.paymentRequest = null;
+
+                clearTimeout(self.authorizationTimeout);
             };
 
             /**
@@ -364,6 +368,8 @@
             self.onCompletePaymentV3 = function (session, result) {
                 self.hasActiveSession = false;
                 self.paymentRequest = null;
+
+                clearTimeout(self.authorizationTimeout);
             };
 
             /**
@@ -386,6 +392,19 @@
             };
 
             /**
+             * Callback for ApplePaySession.completePaymentMethodSelection() for Apple Pay JS version 3 and above.
+             * @param {Object} session - The current ApplePaySession.
+             * @param {Object} applePayPaymentAuthorizedEvent - The event sent to onpaymentauthorized.
+             */
+            self.onPaymentAuthorizedWithTimeout = function (session, applePayPaymentAuthorizedEvent) {
+                session.onpaymentauthorized(applePayPaymentAuthorizedEvent);
+
+                self.authorizationTimeout = setTimeout(() => {
+                    alert('ApplePay Not Finished - The site was not able to complete the payment. Please, trye again');
+                }, 30000);
+            };
+
+            /**
              * Callback for ApplePaySession.completeShippingContactSelection() for Apple Pay JS versions 1 and 2.
              * @param {Object} session - The current ApplePaySession.
              * @param {Number} status - The status code passed to the function.
@@ -403,7 +422,8 @@
                             shippingContact: self.createShippingContact(session)
                         }
                     };
-                    session.onpaymentauthorized(applePayPaymentAuthorizedEvent);
+
+                    self.onPaymentAuthorizedWithTimeout(session, applePayPaymentAuthorizedEvent);
                 }
             };
 
@@ -422,7 +442,8 @@
                             shippingContact: self.createShippingContact(session)
                         }
                     };
-                    session.onpaymentauthorized(applePayPaymentAuthorizedEvent);
+
+                    self.onPaymentAuthorizedWithTimeout(session, applePayPaymentAuthorizedEvent);
                 }
             };
 

--- a/ApplePaySession.js
+++ b/ApplePaySession.js
@@ -400,7 +400,7 @@
                 session.onpaymentauthorized(applePayPaymentAuthorizedEvent);
 
                 self.authorizationTimeout = setTimeout(() => {
-                    alert('ApplePay Not Finished - The site was not able to complete the payment. Please, trye again');
+                    alert('Apple Pay Not Finished - The site was not able to complete the payment. Please, try again.');
                 }, 30000);
             };
 

--- a/ApplePaySession.js
+++ b/ApplePaySession.js
@@ -60,8 +60,8 @@
             };
 
             /**
-             * Sets the time you must complete the payment after "onpaymentauthorized".
-             * @param {Number} milliseconds - Timeout to use in milliseconds;
+             * Sets the time you must complete the payment with after "onpaymentauthorized" is called.
+             * @param {Number} milliseconds - Timeout to use in milliseconds.
              */
             self.setAuthorizationTimeout = function (milliseconds) {
                 self.authorizationTimeout = milliseconds;

--- a/ApplePaySession.js
+++ b/ApplePaySession.js
@@ -18,7 +18,8 @@
             self.paymentRequest = null;
             self.merchantIdentifier = "";
             self.supportedVersions = [];
-            self.authorizationTimeout = 0;
+            self.authorizationTimeout = 30000;
+            self.authorizationTimeoutId = 0;
             self.validationURL = "https://apple-pay-gateway-cert.apple.com/paymentservices/startSession";
             self.version = latestApplePayVersion;
 
@@ -56,6 +57,14 @@
              */
             self.setUserSetupStatus = function (isSetUp) {
                 self.isApplePaySetUp = isSetUp;
+            };
+
+            /**
+             * Sets the time you must complete the payment after "onpaymentauthorized".
+             * @param {Number} milliseconds - Timeout to use in milliseconds;
+             */
+            self.setAuthorizationTimeout = function (milliseconds) {
+                self.authorizationTimeout = milliseconds;
             };
 
             /**
@@ -357,7 +366,7 @@
                 self.hasActiveSession = false;
                 self.paymentRequest = null;
 
-                clearTimeout(self.authorizationTimeout);
+                clearTimeout(self.authorizationTimeoutId);
             };
 
             /**
@@ -369,7 +378,7 @@
                 self.hasActiveSession = false;
                 self.paymentRequest = null;
 
-                clearTimeout(self.authorizationTimeout);
+                clearTimeout(self.authorizationTimeoutId);
             };
 
             /**
@@ -399,9 +408,9 @@
             self.onPaymentAuthorizedWithTimeout = function (session, applePayPaymentAuthorizedEvent) {
                 session.onpaymentauthorized(applePayPaymentAuthorizedEvent);
 
-                self.authorizationTimeout = setTimeout(() => {
+                self.authorizationTimeoutId = setTimeout(() => {
                     alert('Apple Pay Not Finished - The site was not able to complete the payment. Please, try again.');
-                }, 30000);
+                }, self.authorizationTimeout);
             };
 
             /**

--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ delete ApplePaySession.openPaymentSetup;
 
 ### Apple Pay Payment Timeout
 
-[Apple Pay documentantion](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaysession/1778020-onpaymentauthorized) says: the `onpaymentauthorized` function must complete the payment and respond by calling `completePayment` before the 30 second timeout, after which a message appears stating that the payment could not be completed.
+The [Apple Pay documentation](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaysession/1778020-onpaymentauthorized) states:
+
+> The `onpaymentauthorized` function must complete the payment and respond by calling `completePayment` before the 30 second timeout, after which a message appears stating that the payment could not be completed.
 
 You can change this timeout with `setAuthorizationTimeout(milliseconds)`.
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,18 @@ If you need to test compatibility with devices that do not support Apple Pay set
 delete ApplePaySession.openPaymentSetup;
 ```
 
+### Apple Pay Payment Timeout
+
+[Apple Pay documentantion](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaysession/1778020-onpaymentauthorized) says: the `onpaymentauthorized` function must complete the payment and respond by calling `completePayment` before the 30 second timeout, after which a message appears stating that the payment could not be completed.
+
+You can change this timeout with `setAuthorizationTimeout(milliseconds)`.
+
+```js
+ApplePaySessionPolyfill.setAuthorizationTimeout(1000);
+```
+
+By default this value is set to 30000 milliseconds (30 seconds) on polyfill like in the Apple Pay session.
+
 ## Feedback
 
 Any feedback or issues can be added to the [issues](https://github.com/justeat/applepayjs-polyfill/issues) for this project in GitHub.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ You can change this timeout with `setAuthorizationTimeout(milliseconds)`.
 ApplePaySessionPolyfill.setAuthorizationTimeout(1000);
 ```
 
-By default this value is set to 30000 milliseconds (30 seconds) on polyfill like in the Apple Pay session.
+By default this value is set to 30000 milliseconds (30 seconds) in the polyfill like in a real Apple Pay session.
 
 ## Feedback
 


### PR DESCRIPTION
Hi! 

ApplePay has a 30 seconds timeout to client call "onCompletePayment" after "onpaymentauthorized".
Would be cool to have this simple alert to avoid errors on implementation.